### PR TITLE
Fix the broken RadEval and two issues in the tests 

### DIFF
--- a/RadEval/RadEval.py
+++ b/RadEval/RadEval.py
@@ -167,7 +167,8 @@ class RadEval():
                 "f1radbert_ct_accuracy",
                 "f1radbert_ct_micro avg_f1-score",
                 "f1radbert_ct_macro avg_f1-score",
-                "f1radbert_ct_weighted_f1",
+                "f1radbert_ct_weighted_f1"
+            ])
         
         if self.do_hopprchexbert:
             self.metric_keys.extend([

--- a/tests/test_f1chexbert.py
+++ b/tests/test_f1chexbert.py
@@ -4,7 +4,7 @@ import numpy as np
 
 def test_f1chexbert():
     f1chexbert = F1CheXbert()
-    accuracy, accuracy_not_averaged, class_report, class_report_5 = f1chexbert(
+    accuracy, accuracy_not_averaged, class_report, class_report_5, _, _ = f1chexbert(
         hyps=['No pleural effusion. Normal heart size.',
               'Normal heart size.',
               'Increased mild pulmonary edema and left basal atelectasis.',

--- a/tests/test_hopprf1chexbert.py
+++ b/tests/test_hopprf1chexbert.py
@@ -1,5 +1,24 @@
+import os
+import logging
+import pytest
 from RadEval.factual.hoppr_f1chexbert import HopprF1CheXbert
 import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+# Keep in sync with the hard-coded path in RadEval/factual/hoppr_f1chexbert.py
+_HOPPR_CHEXPERT_CKPT = "/fss/pranta_das/CheXbert/expermints_folder/25507/checkpoint_2.pth"
+
+if not os.path.exists(_HOPPR_CHEXPERT_CKPT):
+    logger.warning(
+        "Skipping test_hopprf1chexbert because the model checkpoint is missing: %s",
+        _HOPPR_CHEXPERT_CKPT,
+    )
+    pytest.skip(
+        f"Missing Hoppr CheXbert checkpoint: {_HOPPR_CHEXPERT_CKPT}",
+        allow_module_level=True,
+    )
 
 
 def test_f1chexbert():


### PR DESCRIPTION
Big thanks to the authors for making this tool available :heart: 

This is small commit with the following fixes:
- Fixed a typo (open parentheses) which broke the main script, `RadEval.py`.
- Added placeholders for the missing outputs on the f1chexbert call in `test_f1chexbert.py`.
- Added code which skips the test which uses the Hoppr model if the model is not present in `/fss/pranta_das/CheXbert/expermints_folder/25507/checkpoint_2.pth`. This way if some user or potential contributor runs the tests, they will all pass or be skipped.

Some notes/questions:

- Is this model from Hoppr a proprietary one, or can one access/download it somehow? If it is the latter, I could add code which fetches it in the context of the test, might also be nice to add the info in the readme. Otherwise, skipping it if not available seems like a reasonable approach. What do you think?
- It would be great to have some info in the readme for contributors.