### PR TITLE
fix(setup): include radfact_ct prompts and bertscore DeBERTa baselines in wheel (v2.2.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 *.pyo
 *.pyd
 *.pytest_cache/
+build/
+dist/
 
 # Ignore log files
 *.log

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='radeval',
-    version='2.2.1',
+    version='2.2.2',
     author='Jean-Benoit Delbrouck, Justin Xu, Xi Zhang, Dave Van Veen',
     maintainer='Xi Zhang, JB Delbrouck',
     url='https://github.com/jbdel/RadEval',

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,11 @@ setup(
         "radeval.metrics.SRRBert": ["*.json"],
         "radeval.metrics.bertscore._vendor": [
             "rescale_baseline/*/*.tsv",
+            "rescale_baseline/*/*/*.tsv",
+        ],
+        "radeval.metrics.radfact_ct": [
+            "prompts/ct/*.txt",
+            "prompts/ct/*.json",
         ],
     },
     zip_safe=False,

--- a/tests/test_radfact_ct.py
+++ b/tests/test_radfact_ct.py
@@ -27,6 +27,30 @@ class TestRadFactCTUnit:
     def test_import(self):
         assert RadFactCT is not None
 
+    def test_prompt_files_readable(self):
+        """All six prompt files must be readable from the installed package location.
+
+        This test catches wheel packaging omissions: unlike asserting Path.exists()
+        against the source tree, these loaders use Path(__file__).parent internally
+        and will raise FileNotFoundError if the files are absent post-install.
+        """
+        from radeval.metrics.radfact_ct.radfact_ct import (
+            _load_report_to_phrases_prompts,
+            _load_negative_filtering_prompts,
+            _load_nli_prompts,
+        )
+        system, pairs = _load_report_to_phrases_prompts()
+        assert isinstance(system, str) and len(system) > 0
+        assert len(pairs) > 0
+
+        system, pairs = _load_negative_filtering_prompts()
+        assert isinstance(system, str) and len(system) > 0
+        assert len(pairs) > 0
+
+        system, pairs = _load_nli_prompts()
+        assert isinstance(system, str) and len(system) > 0
+        assert len(pairs) > 0
+
     def test_missing_api_key(self):
         old = os.environ.pop("OPENAI_API_KEY", None)
         try:


### PR DESCRIPTION
## Summary

- `radfact_ct/prompts/ct/` has no `__init__.py` so setuptools never included its 6 prompt files in the wheel — every call to `RadFactCT` raised `FileNotFoundError` after `pip install radeval`
- `bertscore` glob `rescale_baseline/*/*.tsv` was one level too shallow, silently dropping 6 DeBERTa baseline TSVs from the wheel (latent `ValueError` for users passing a DeBERTa `model_type`)
- Added `test_prompt_files_readable` which calls the prompt-loader functions directly — catches packaging omissions by using `Path(__file__).parent` internally, so it would raise `FileNotFoundError` against a broken installed wheel
- Bumped version to 2.2.2

## Test plan

- [x] `pytest tests/test_radfact_ct.py::TestRadFactCTUnit` — all unit tests pass (no API key needed)
- [x] Build wheel and verify artifact: `python -m build --wheel && python -c "import zipfile,glob; contents=zipfile.ZipFile(sorted(glob.glob('dist/*.whl'))[-1]).namelist(); assert 'radeval/metrics/radfact_ct/prompts/ct/report_to_phrases_system.txt' in contents"`